### PR TITLE
Deregister unused table metrics on blob flush

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/FlushService.java
@@ -561,6 +561,11 @@ class FlushService<T> {
     return upload(blobPath, blob.blobBytes, blob.chunksMetadataList, blob.blobStats);
   }
 
+  static String tableBlobMetricName(String dbName, String schemaName, String tableName) {
+    String metricBaseName = MetricRegistry.name("table_blob", "size", "histogram");
+    return String.format("%s,db=%s,schema=%s,table=%s", metricBaseName, dbName, schemaName, tableName);
+  }
+
   /**
    * Upload a blob to Streaming Ingest dedicated stage
    *
@@ -603,8 +608,7 @@ class FlushService<T> {
       }
 
       for (ChunkMetadata chunkMetadata: metadata) {
-        String metricBaseName = MetricRegistry.name("table_blob", "size", "histogram");
-        String metricName = String.format("%s,db=%s,schema=%s,table=%s", metricBaseName, chunkMetadata.getDBName(), chunkMetadata.getSchemaName(), chunkMetadata.getTableName());
+        String metricName = tableBlobMetricName(chunkMetadata.getDBName(), chunkMetadata.getSchemaName(), chunkMetadata.getTableName());
         this.owningClient.metrics.histogram(metricName).update(chunkMetadata.getChunkLength());
       }
     }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelInternal.java
@@ -296,6 +296,10 @@ class SnowflakeStreamingIngestChannelInternal<T> implements SnowflakeStreamingIn
                   this.owningClient.verifyChannelsAreFullyCommitted(
                       Collections.singletonList(this));
 
+              // Deregister per-table metrics.
+              String metricName = FlushService.tableBlobMetricName(getDBName(), getSchemaName(), getTableName());
+              this.owningClient.metrics.remove(metricName);
+
               this.rowBuffer.close("close");
               this.owningClient.removeChannelIfSequencersMatch(this);
 


### PR DESCRIPTION
We are running into issues where some "ghost" table metrics are being reported. This happens because we only deregister metrics when the client is closed, but it is possible we stop sending data for a table before the entire client is closed, in which case the last known value keeps getting reported.

Tested in testbox. At a high-level, just printed out the metric names with table_blob in them, and made sure they match the ones in the actual blob.

Alternatively, we could deregister the metric when the channel is closed (maybe cleaner). But technically, someone could open a channel, send data, and stop sending data without closing the channel, so I'll try this first.