### PR TITLE
Flush channels individually if interleaving is disabled

### DIFF
--- a/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestChannel.java
+++ b/src/main/java/net/snowflake/ingest/streaming/SnowflakeStreamingIngestChannel.java
@@ -292,4 +292,6 @@ public interface SnowflakeStreamingIngestChannel {
    * Requests owning client to flush this channel as soon as possible
    */
   void setNeedFlush();
+
+  boolean getNeedFlush();
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/ChannelRuntimeState.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/ChannelRuntimeState.java
@@ -11,6 +11,8 @@ class ChannelRuntimeState {
   // Indicates whether the channel is still valid
   private volatile boolean isValid;
 
+  private volatile boolean needFlush;
+
   // The channel's current start offset token
   private volatile String startOffsetToken;
 
@@ -28,6 +30,7 @@ class ChannelRuntimeState {
     this.endOffsetToken = endOffsetToken;
     this.rowSequencer = new AtomicLong(rowSequencer);
     this.isValid = isValid;
+    this.needFlush = false;
   }
 
   /**
@@ -93,5 +96,13 @@ class ChannelRuntimeState {
   /** Get the insert timestamp of the last row in the current row buffer */
   Long getLastInsertInMs() {
     return this.lastInsertInMs;
+  }
+
+  public void setNeedFlush(boolean needFlush) {
+    this.needFlush = needFlush;
+  }
+
+  public boolean getNeedFlush() {
+    return this.needFlush;
   }
 }

--- a/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
+++ b/src/main/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestClientInternal.java
@@ -758,7 +758,7 @@ public class SnowflakeStreamingIngestClientInternal<T> implements SnowflakeStrea
     if (isClosed && !closing) {
       throw new SFException(ErrorCode.CLOSED_CLIENT);
     }
-    return this.flushService.flush(true);
+    return this.flushService.flush(closing);
   }
 
   /** Set the flag to indicate that a flush is needed */

--- a/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
+++ b/src/test/java/net/snowflake/ingest/streaming/internal/SnowflakeStreamingIngestChannelTest.java
@@ -834,6 +834,7 @@ public class SnowflakeStreamingIngestChannelTest {
     Mockito.doReturn(response).when(client).getChannelsStatus(Mockito.any());
 
     Assert.assertFalse(channel.isClosed());
+    Assert.assertFalse(channel.getNeedFlush());
     channel.close().get();
     Assert.assertTrue(channel.isClosed());
 
@@ -868,6 +869,7 @@ public class SnowflakeStreamingIngestChannelTest {
     Mockito.doReturn(response).when(client).getChannelsStatus(Mockito.any());
 
     Assert.assertFalse(channel.isClosed());
+    Assert.assertFalse(channel.getNeedFlush());
     Mockito.doNothing().when(client).dropChannel(Mockito.any());
     channel.close(true).get();
     Assert.assertTrue(channel.isClosed());


### PR DESCRIPTION
The FlushService tries to flush all channels for the same table, however this has the downside of causing some channels to be included when they are not exactly ready. and the next time they do need to flush, the blob size is smaller than anticipated. To fix that the need for flush is now maintained in the channel object and the channel cache queries the channels to know which needs to flush.

The other issue is that by handling the need to flush at the table level, it leads to race codition where one channel requests flush, while another channel just flushed and turn the need flush flag off, so the caller waits forever.